### PR TITLE
fix dup off-by-one, swap underflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,7 +397,7 @@ where
 
                     Op::Swap => {
                         if sp < 2 {
-                            return Err(Failure::Fault(Fault::DupUnderflow));
+                            return Err(Failure::Fault(Fault::StackUnderflow));
                         }
 
                         let tmp = stack[sp - 1];
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn underflow() {
-        fault(&[Op::Add], Fault::StackUnderflow);
+        fault(&[Op::Push(0), Op::Add], Fault::StackUnderflow);
     }
 
     #[test]
@@ -686,6 +686,11 @@ mod tests {
     #[test]
     fn drop_underflow() {
         fault(&[Op::Drop], Fault::DropUnderflow);
+    }
+
+    #[test]
+    fn swap_underflow() {
+        fault(&[Op::Push(0), Op::Swap], Fault::StackUnderflow);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub enum Fault {
     /// Attempt to drop on an empty stack
     DropUnderflow,
 
-    /// Attempt to dup onto a full stack
+    /// Attempt to dup on an empty stack
     DupUnderflow,
 
     /// Attempt to call a function with an insufficient number of
@@ -344,7 +344,7 @@ where
             return Err(Failure::Fault(Fault::DupUnderflow));
         }
 
-        push(stack, sp, stack[sp])
+        push(stack, sp, stack[sp - 1])
     }
 
     loop {
@@ -686,6 +686,18 @@ mod tests {
     #[test]
     fn drop_underflow() {
         fault(&[Op::Drop], Fault::DropUnderflow);
+    }
+
+    #[test]
+    fn dup() {
+        let op = [
+            Op::Push(0x02),
+            Op::Dup,
+            Op::Add,
+            Op::Done,
+        ];
+
+        run(&op, Some(&[Some(0x04)])).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
dup was broken; now it's not.

I ran grcov and took a look at the code that had 0 coverage. `dup` looked suspicious.

Also, `swap` was returning a `DupUnderflow` which would be confusing; I switched it to a generic `StackUnderflow`, which is now used directly in a few places: `Add` and `Branch*` (via `operands`) and `Swap`.