### PR TITLE
Add expand/collect32, Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hif"
-version = "0.4.0"
+version = "0.3.0"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hif"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hif"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -9,4 +9,3 @@ license = "MPL-2.0"
 postcard = "0.7.0"
 serde = { version = "1.0.126", default-features = false }
 pkg-version = { version = "1.0.0" }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,16 +143,6 @@ pub enum Op {
     /// Bitwise XOR top two elements of the stack, replacing them with result
     Xor,
 
-    /// Expands the top `u32` from the stack into four `u8`
-    ///
-    /// The highest byte of the `u32` ends up at the top of the stack
-    Expand32,
-
-    /// Collects four `u8` from the top of the stack into a single `u32`
-    ///
-    /// The top of the stack ends up as the highest byte of the `u32`
-    Collect32,
-
     /// Compare the top two elements of the stack, branching if the topmost
     /// is less than the second topmost
     BranchLessThan(Target),
@@ -177,6 +167,20 @@ pub enum Op {
 
     /// Denote the end of execution. All execution must end with `Done`
     Done,
+
+    // XXX These operations live at the bottom instead of with other arithmetic
+    // operations to avoid a flag day, since rearranging order would break the
+    // existing encoding.
+    //
+    /// Expands the top `u32` from the stack into four `u8`
+    ///
+    /// The highest byte of the `u32` ends up at the top of the stack
+    Expand32,
+
+    /// Collects four `u8` from the top of the stack into a single `u32`
+    ///
+    /// The top of the stack ends up as the highest byte of the `u32`
+    Collect32,
 }
 
 ///


### PR DESCRIPTION
I was writing a loop in HIF that used the `send` primitive to call a function that took a `u32`, and ran into some trouble.

The `send` primitive expects function arguments to be packed as a bunch of `u8` in the stack, so the `u32` ends up taking four stack slots.  Each stack slot is a `u32`, with only the LSB used.

However, this makes it impossible to do a loop with a `u32` start and end value: we need to have `[u8, u8, u8, u8]` to do the `send` call, but want a single `[u32]` to increment and compare against the end value.  There's no way to rearrange data in the HIF stack from `[u8, u8, u8, u8]` to `[u32]`, since we don't have shift or multiplication.

This PR adds `Expand32` and `Collapse32`, which are complimentary operations that do this rearranging.