### PR TITLE
Add From<Fault> for Failure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,12 @@ pub enum Failure {
     FunctionError(u32),
 }
 
+impl From<Fault> for Failure {
+    fn from(f: Fault) -> Self {
+        Self::Fault(f)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub enum FunctionResult<'a> {
     Success(&'a [u8]),


### PR DESCRIPTION
This lets code avoid writing `Failure::Fault(...)` a lot, by exploiting the fact that the ? operator invokes a From impl if available.

There currently aren't a lot of opportunities to use this in HIF itself because the HIF code heavily prefers "return Err(...)" to using ?. However, it's making my Hiffy changes easier.